### PR TITLE
🔖 Update CHANGELOG for release 0.0.3 and bump version to 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,11 @@
 
 
-## Unreleased
+## Release [0.0.3]
 - feat: Added all country codes
 - feat: Added search and optimized dialog with debounce
 
-## 0.0.2
+## Release [0.0.2]
 INITIAL RELEASE
 
-## 0.0.1
-
+## Release [0.0.1]
 INITIAL RELEASE

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobile_number_input
 description: "Customizable widget for entering phone numbers with country code selector."
-version: 0.0.3
+version: 0.0.4
 repository: https://github.com/amadejzr/mobile_number_input
 
 environment:


### PR DESCRIPTION
Transition 'Unreleased' features to 'Release [0.0.3]' in CHANGELOG and prepare for next development iteration by updating version in pubspec.yaml.